### PR TITLE
Scale life force by delta time

### DIFF
--- a/FloatMyHouse.Unity/Assets/Code/Model/Balloon.cs
+++ b/FloatMyHouse.Unity/Assets/Code/Model/Balloon.cs
@@ -8,6 +8,7 @@ public class Balloon
 	private const float InitialFuelLevel = 100;
 	private const float FuelConsumedPerSecond = 10;
 	private const float RefuelPerSecond = 50;
+	private const float ForcePerSecond = 600;
 
 	private readonly ISubject<BalloonEvent> _events = new Subject<BalloonEvent>();
 	public IObservable<BalloonEvent> Events => _events;
@@ -92,7 +93,9 @@ public class Balloon
 
 			_currentFuelLevel -= fuelConsumed;
 
-			_events.OnNext(new LiftAddedEvent());
+			var liftForce = ForcePerSecond * tickEvent.DeltaTime;
+
+			_events.OnNext(new LiftAddedEvent(liftForce));
 			_events.OnNext(new FuelConsumedEvent(fuelConsumed, _currentFuelLevel));
 		}
 		else

--- a/FloatMyHouse.Unity/Assets/Code/Model/LiftAddedEvent.cs
+++ b/FloatMyHouse.Unity/Assets/Code/Model/LiftAddedEvent.cs
@@ -1,4 +1,9 @@
 ﻿public class LiftAddedEvent : BalloonEvent
 {
+	public float Force { get; }
 
+	public LiftAddedEvent(float force)
+	{
+		Force = force;
+	}
 }

--- a/FloatMyHouse.Unity/Assets/Code/Presentation/BalloonPresenter.cs
+++ b/FloatMyHouse.Unity/Assets/Code/Presentation/BalloonPresenter.cs
@@ -5,14 +5,14 @@ using Zenject;
 public class BalloonPresenter : MonoBehaviour
 {
 	public Rigidbody2D BalloonRigidBody;
-	public float Magnitude;
+	public float ConstantForcePerSecond = 60;
 
 	[Inject]
 	public void Initialize(Balloon balloonModel)
 	{
 		balloonModel.Events
 			.OfType<BalloonEvent, LiftAddedEvent>()
-			.Subscribe(_ => AddUpForce(Magnitude));
+			.Subscribe(e => AddUpForce(e.Force));
 
 		Observable.EveryLateUpdate()
 			.Select(_ => (Vector2)transform.position)
@@ -22,7 +22,7 @@ public class BalloonPresenter : MonoBehaviour
 
 	void Update()
 	{
-		AddUpForce(1);
+		AddUpForce(ConstantForcePerSecond * Time.deltaTime);
 	}
 
 	private void AddUpForce(float force)

--- a/FloatMyHouse.Unity/ProjectSettings/ProjectSettings.asset
+++ b/FloatMyHouse.Unity/ProjectSettings/ProjectSettings.asset
@@ -106,6 +106,11 @@ PlayerSettings:
   xboxOneDisableEsram: 0
   xboxOnePresentImmediateThreshold: 0
   switchQueueCommandMemory: 0
+  switchQueueControlMemory: 16384
+  switchQueueComputeMemory: 262144
+  switchNVNShaderPoolsGranularity: 33554432
+  switchNVNDefaultPoolsGranularity: 16777216
+  switchNVNOtherPoolsGranularity: 16777216
   vulkanEnableSetSRGBWrite: 0
   m_SupportedAspectRatios:
     4:3: 1
@@ -390,6 +395,7 @@ PlayerSettings:
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
   switchUserAccountLockEnabled: 0
+  switchSystemResourceMemory: 16777216
   switchSupportedNpadStyles: 3
   switchNativeFsCacheSize: 32
   switchIsHoldTypeHorizontal: 0


### PR DESCRIPTION
Turns out that Low quality settings lack a frame rate limiter (vsync), exposing some laziness / jam short-cutting